### PR TITLE
Bugfix in spell_check_files()

### DIFF
--- a/R/check-files.R
+++ b/R/check-files.R
@@ -16,8 +16,8 @@ spell_check_files <- function(path, ignore = character(), lang = "en_US"){
   stopifnot(is.character(ignore))
   lang <- normalize_lang(lang)
   dict <- hunspell::dictionary(lang, add_words = ignore)
-  path <- normalizePath(path, mustWork = TRUE)
-  lines <- lapply(sort(path), spell_check_file_one, dict = dict)
+  path <- sort(normalizePath(path, mustWork = TRUE))
+  lines <- lapply(path, spell_check_file_one, dict = dict)
   summarize_words(path, lines)
 }
 


### PR DESCRIPTION
Words were not matched to the correct file in the internal `summarize_words()` function due
to different orders of the input lists.