### PR TITLE
Ensure that `spell_check_setup()` doesn't induce a `goodpractice::gp()` error

### DIFF
--- a/R/spell-check.R
+++ b/R/spell-check.R
@@ -137,8 +137,9 @@ spell_check_setup <- function(pkg = ".", vignettes = TRUE, lang = "en-US", error
   update_description(pkg, lang = lang)
   update_wordlist(pkg, vignettes = vignettes)
   dir.create(file.path(pkg$path, "tests"), showWarnings = FALSE)
-  writeLines(sprintf("if(requireNamespace('spelling', quietly=TRUE))
-  spelling::spell_check_test(vignettes = %s, error = %s, skip_on_cran = TRUE)",
+  writeLines(sprintf("if(requireNamespace('spelling', quietly = TRUE))
+  spelling::spell_check_test(vignettes = %s, error = %s,
+                             skip_on_cran = TRUE)",
     deparse(vignettes), deparse(error)), file.path(pkg$path, "tests/spelling.R"))
   cat(sprintf("Updated %s\n", file.path(pkg$path, "tests/spelling.R")))
 }


### PR DESCRIPTION
As it stands, the `spelling.R` file created by `spell_check_setup()` has a line beyond 80 characters, which `goodpractice::gp()` complains about. This is a small point but I guess that it would be good to rectify this.
Just to clarify, I'm not suggesting that the whole `spelling` package should itself conform to this 80 char limit, I'm just saying that perhaps the files that it writes to other packages should.
Thanks,
Rory