### PR TITLE
cross references in bookdown

### DIFF
--- a/R/parse-markdown.R
+++ b/R/parse-markdown.R
@@ -30,6 +30,8 @@ parse_text_md <- function(path, extensions = TRUE, yaml_fields = c("title" ,"sub
     paste0(collapse = "\n", xml2::xml_text(xml2::xml_find_all(x, "./text")))
   }, character(1))
 
+  values <- gsub("\\{\\#.*\\}", "", values)
+
   data.frame(
     text = values,
     position = sourcepos,

--- a/R/parse-markdown.R
+++ b/R/parse-markdown.R
@@ -30,7 +30,8 @@ parse_text_md <- function(path, extensions = TRUE, yaml_fields = c("title" ,"sub
     paste0(collapse = "\n", xml2::xml_text(xml2::xml_find_all(x, "./text")))
   }, character(1))
 
-  values <- gsub("\\{\\#.*\\}", "", values)
+  # Strip 'heading identifiers', see: https://pandoc.org/MANUAL.html#heading-identifiers
+  values <- gsub('\\{#[^\\n]+\\}\\s*($|\\r?\\n)', '\\1', values, perl = TRUE)
 
   data.frame(
     text = values,


### PR DESCRIPTION
I've just realized the WORDLIST in dev_guide is full of things that are ["heading identifiers"](https://pandoc.org/MANUAL.html#heading-identifiers).

This is a fix but probably not the best one.