### PR TITLE
Explicitly pass macros=NULL to tools::loadPkgRdMacros().

### DIFF
--- a/R/spell-check.R
+++ b/R/spell-check.R
@@ -56,7 +56,7 @@ spell_check_package <- function(pkg = ".", vignettes = TRUE, use_wordlist = TRUE
   rd_files <- sort(list.files(file.path(pkg$path, "man"), "\\.rd$", ignore.case = TRUE, full.names = TRUE))
   macros <- tools::loadRdMacros(
     file.path(R.home("share"), "Rd", "macros", "system.Rd"),
-    tools::loadPkgRdMacros(pkg$path)
+    tools::loadPkgRdMacros(pkg$path, macros = NULL)
   )
   rd_lines <- lapply(rd_files, spell_check_file_rd, dict = dict, macros = macros)
 


### PR DESCRIPTION
I have a CI job that runs my package with R 3.2.5. Recently `spelling::spell_check_test()` has started to fail only on R 3.2.5 with the following error:

```
Error in tools::loadPkgRdMacros(pkg$path) : 
  argument "macros" is missing, with no default
Calls: <Anonymous> -> spell_check_package -> <Anonymous> -> <Anonymous>
```

I believe this was introduced in 540624d179dbd1c8c955d10a89503a0abff70ce5 from PR #44 and recently released to CRAN in version 2.2.

To reproduce the error, I updated the `.travis.yml` file on my fork of the repository to run in both R 3.2.5 and R 3.3.0.

```
matrix:
  include:
    - os: linux
      r: 3.2.5
      r_binary_packages: digest
    - os: linux
      r: 3.3.0
```

Below are links to the Travis log files:

### R 3.2.5

https://travis-ci.com/github/jdblischak/spelling/jobs/443397555#L1688

```
* checking tests ...
  Running ‘spelling.R’
 ERROR
Running the tests in ‘tests/spelling.R’ failed.
Last 13 lines of output:
  R is a collaborative project with many contributors.
  Type 'contributors()' for more information and
  'citation()' on how to cite R or R packages in publications.
  
  Type 'demo()' for some demos, 'help()' for on-line help, or
  'help.start()' for an HTML browser interface to help.
  Type 'q()' to quit R.
  
  > spelling::spell_check_test(vignettes = TRUE, error = FALSE)
  Error in tools::loadPkgRdMacros(pkg$path) : 
    argument "macros" is missing, with no default
  Calls: <Anonymous> -> spell_check_package -> <Anonymous> -> <Anonymous>
  Execution halted
```

### R 3.3.0

https://travis-ci.com/github/jdblischak/spelling/jobs/443397556#L891

```
* checking tests ...
  Running ‘spelling.R’
  Comparing ‘spelling.Rout’ to ‘spelling.Rout.save’ ... OK
```