### PR TITLE
Replace 'whitelist' as a verb to 'allow'

### DIFF
--- a/R/spell-check.R
+++ b/R/spell-check.R
@@ -6,7 +6,7 @@
 #' package `DESCRIPTION` file.
 #'
 #' The preferred spelling language (typically `en-GB` or `en-US`) should be specified
-#' in the `Language` field from your package `DESCRIPTION`. To whitelist custom words
+#' in the `Language` field from your package `DESCRIPTION`. To allow custom words,
 #' use the package [WORDLIST][get_wordlist] file which will be added to the dictionary
 #' when spell checking. See [update_wordlist] to automatically populate and update this
 #' file.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ spell_check_package("~/workspace/V8")
 # Yihui         JS.Rd:26
 ```
 
-Review these words and then whitelist them:
+Review these words and then update the wordlist to allow them:
 
 
 ```r

--- a/man/spell_check_package.Rd
+++ b/man/spell_check_package.Rd
@@ -33,7 +33,7 @@ Parses and checks R manual pages, rmd/rnw vignettes, and text fields in the
 package \code{DESCRIPTION} file.
 
 The preferred spelling language (typically \code{en-GB} or \code{en-US}) should be specified
-in the \code{Language} field from your package \code{DESCRIPTION}. To whitelist custom words
+in the \code{Language} field from your package \code{DESCRIPTION}. To allow custom words,
 use the package \link[=get_wordlist]{WORDLIST} file which will be added to the dictionary
 when spell checking. See \link{update_wordlist} to automatically populate and update this
 file.


### PR DESCRIPTION
There were a couple of places in the documentation where the word "whitelist" is used as a verb, which could be replaced with the word "allow".