### PR TITLE
Add support for spell checking quarto files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,5 +22,5 @@ Imports:
   knitr
 Suggests: pdftools 
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3.9000
+RoxygenNote: 7.3.1
 Language: en-GB

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+dev
+
+  - Support for spellchecking on Quarto files (@olivroy, #77)
+
 2.2.1
   - Fix for commonmark 1.7.0 change for auto-linked markdown URLs
 

--- a/R/check-files.R
+++ b/R/check-files.R
@@ -30,7 +30,7 @@ spell_check_files <- function(path, ignore = character(), lang = "en_US"){
 }
 
 spell_check_file_one <- function(path, dict){
-  if(grepl("\\.r?md$",path, ignore.case = TRUE))
+  if(grepl("\\.r?q?md$",path, ignore.case = TRUE))
     return(spell_check_file_md(path, dict = dict))
   if(grepl("\\.rd$", path, ignore.case = TRUE))
     return(spell_check_file_rd(path, dict = dict))

--- a/R/parse-markdown.R
+++ b/R/parse-markdown.R
@@ -47,7 +47,7 @@ parse_text_md <- function(path, extensions = TRUE, yaml_fields = c("title" ,"sub
   values <- gsub("\\(ref:.*?\\)", "", values)
 
   # Strip Quarto text references, @sec-, @fig- @eq- etc. https://quarto.org/docs/authoring/cross-reference-options.html
-  values <- gsub("\\@\\(\\w+\\-.*?\\)", "", values)
+  values <- gsub("\\@\\w+\\-[[:graph:]]+", "", values)
 
   data.frame(
     text = values,

--- a/R/parse-markdown.R
+++ b/R/parse-markdown.R
@@ -46,8 +46,9 @@ parse_text_md <- function(path, extensions = TRUE, yaml_fields = c("title" ,"sub
   # Strip bookdown text references, see: https://bookdown.org/yihui/bookdown/markdown-extensions-by-bookdown.html#text-references
   values <- gsub("\\(ref:.*?\\)", "", values)
 
-  # Strip Quarto text references, @sec-, @fig- @eq- etc. https://quarto.org/docs/authoring/cross-reference-options.html
-  values <- gsub("\\@\\w+\\-[[:graph:]]+", "", values)
+  # Quarto references start with @, for example @sec-, @fig- @eq- etc. https://quarto.org/docs/authoring/cross-reference-options.html
+  # No special regex is necessary since all words containing @ are removed from
+  # spell check #9
 
   data.frame(
     text = values,

--- a/R/parse-markdown.R
+++ b/R/parse-markdown.R
@@ -46,6 +46,9 @@ parse_text_md <- function(path, extensions = TRUE, yaml_fields = c("title" ,"sub
   # Strip bookdown text references, see: https://bookdown.org/yihui/bookdown/markdown-extensions-by-bookdown.html#text-references
   values <- gsub("\\(ref:.*?\\)", "", values)
 
+  # Strip Quarto text references, @sec-, @fig- @eq- etc. https://quarto.org/docs/authoring/cross-reference-options.html
+  values <- gsub("\\@\\(\\w+\\-.*?\\)", "", values)
+
   data.frame(
     text = values,
     position = sourcepos,

--- a/R/spell-check.R
+++ b/R/spell-check.R
@@ -72,9 +72,9 @@ spell_check_package <- function(pkg = ".", vignettes = TRUE, use_wordlist = TRUE
 
   if(isTRUE(vignettes)){
     # Where to check for rmd/md files
-    vign_files <- list.files(file.path(pkg$path, "vignettes"), pattern = "\\.r?md$",
+    vign_files <- list.files(file.path(pkg$path, "vignettes"), pattern = "\\.q?r?md$",
                              ignore.case = TRUE, full.names = TRUE, recursive = TRUE)
-    root_files <- list.files(pkg$path, pattern = "(readme|news|changes|index).r?md",
+    root_files <- list.files(pkg$path, pattern = "(readme|news|changes|index).r?q?md",
                              ignore.case = TRUE, full.names = TRUE)
 
     # Markdown vignettes

--- a/man/spell_check_files.Rd
+++ b/man/spell_check_files.Rd
@@ -12,7 +12,7 @@ spell_check_text(text, ignore = character(), lang = "en_US")
 \arguments{
 \item{path}{path to file or to spell check}
 
-\item{ignore}{character vector with words which will be added to the \link[hunspell:dictionary]{hunspell::dictionary}}
+\item{ignore}{character vector with words which will be added to the \link[hunspell:hunspell]{hunspell::dictionary}}
 
 \item{lang}{set \code{Language} field in \code{DESCRIPTION} e.g. \code{"en-US"} or \code{"en-GB"}.
 For supporting other languages, see the \href{https://docs.ropensci.org/hunspell/articles/intro.html#hunspell-dictionaries}{hunspell vignette}.}
@@ -38,7 +38,8 @@ files <- list.files(system.file("examples", package = "knitr"),
 spell_check_files(files)
 }
 \seealso{
-Other spelling: \code{\link{spell_check_package}()},
-  \code{\link{wordlist}}
+Other spelling: 
+\code{\link{spell_check_package}()},
+\code{\link{wordlist}}
 }
 \concept{spelling}

--- a/man/spell_check_package.Rd
+++ b/man/spell_check_package.Rd
@@ -49,7 +49,8 @@ Hunspell includes dictionaries for \code{en_US} and \code{en_GB} by default. Oth
 require installation of a custom dictionary, see \link[hunspell:hunspell]{hunspell} for details.
 }
 \seealso{
-Other spelling: \code{\link{spell_check_files}()},
-  \code{\link{wordlist}}
+Other spelling: 
+\code{\link{spell_check_files}()},
+\code{\link{wordlist}}
 }
 \concept{spelling}

--- a/man/wordlist.Rd
+++ b/man/wordlist.Rd
@@ -31,7 +31,8 @@ removes words from the wordlist that no longer appear as spelling errors, either
 they have been removed from the documentation or added to the \code{lang} dictionary.
 }
 \seealso{
-Other spelling: \code{\link{spell_check_files}()},
-  \code{\link{spell_check_package}()}
+Other spelling: 
+\code{\link{spell_check_files}()},
+\code{\link{spell_check_package}()}
 }
 \concept{spelling}


### PR DESCRIPTION
Fix #77 

A reprex that includes cross-references as well

````r
temp_file <- tempfile(fileext = ".qmd")
writeLines(
    "
This is correct.
This is an eeerrrooorrr.
# Header
```{r}
#| label: fig-weirdooo
#| fig-cap: Will not detect errrors here, but it is a good enough start
foooo <- function() TRUE
foooo()
```
This is @fig-weirdooo for thiiis
",
temp_file
)

spelling::spell_check_files(temp_file)
  WORD           FOUND IN
eeerrrooorrr   file4d5c1a4c6c37.qmd:2
thiiis         file4d5c1a4c6c37.qmd:10
````