### PR TITLE
Support clickable hyperlinks to spelling errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,9 @@ Imports:
   xml2, 
   hunspell (>= 3.0),
   knitr
-Suggests: pdftools 
+Suggests: 
+    cli,
+    pdftools
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
 Language: en-GB

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+dev
+  - spell_check_*() now display cli hyperlinks in console if your console
+    supports it (@olivroy, #74)
+
 2.3.0
   - Support for spellchecking on Quarto files (@olivroy, #77)
   - You can now specify a global wordlist file via the SPELLING_WORDLIST envvar

--- a/R/spell-check.R
+++ b/R/spell-check.R
@@ -123,6 +123,20 @@ summarize_words <- function(file_names, found_line){
       paste0(basename(file_names[i]), ":", found_line[[i]][word])
     }, character(1))
   })
+  # Gather full file names
+  out$file_names <- lapply(bad_words, function(word) {
+    index <- which(vapply(words_by_file, `%in%`, x = word, logical(1)))
+    reports <- vapply(index, function(i){
+      file_names[i]
+    }, character(1))
+  })
+  # gather line numbers for each match for each file.
+  out$line_numbers <- lapply(bad_words, function(word) {
+    index <- which(vapply(words_by_file, `%in%`, x = word, logical(1)))
+    reports <- lapply(index, function(i){
+      as.integer(unlist(strsplit(found_line[[i]][word], split = ",", fixed = TRUE)))
+    })
+  })
   structure(out, class = c("summary_spellcheck", "data.frame"))
 }
 

--- a/R/spell-check.R
+++ b/R/spell-check.R
@@ -150,10 +150,28 @@ print.summary_spellcheck <- function(x, ...){
   fmt <- paste0("%-", max(nchar(words), 0) + 3, "s")
   pretty_names <- sprintf(fmt, words)
   cat(sprintf(fmt, "  WORD"), "  FOUND IN\n", sep = "")
-  for(i in seq_len(nrow(x))){
-    cat(pretty_names[i])
-    cat(paste(x$found[[i]], collapse = paste0("\n", sprintf(fmt, ""))))
-    cat("\n")
+  if (cli::ansi_has_hyperlink_support()) {
+    for(i in seq_len(nrow(x))){
+      # print word
+      cat(pretty_names[i])
+      for (j in seq_along(x$file_names[[i]])) {
+        # each file name
+        # print separator only for subsequent files
+        if (j != 1) cat(paste0("\n", sprintf(fmt, "")))
+
+        for (k in seq_along(x$line_numbers[[i]][[j]])) {
+          # link for each line of each file.
+          if (k == 1) cat(x$found[[i]][[j]])
+        }
+      }
+      cat("\n")
+    }
+  } else {
+    for(i in seq_len(nrow(x))){
+      cat(pretty_names[i])
+      cat(paste(x$found[[i]], collapse = paste0("\n", sprintf(fmt, ""))))
+      cat("\n")
+    }
   }
   invisible(x)
 }

--- a/R/spell-check.R
+++ b/R/spell-check.R
@@ -151,54 +151,59 @@ print.summary_spellcheck <- function(x, ...){
   pretty_names <- sprintf(fmt, words)
   cat(sprintf(fmt, "  WORD"), "  FOUND IN\n", sep = "")
 
-  # Diplay cli hyperlinks if console supports it.
-  # Show in RStudio interactively .
-  # https://github.com/ropensci/spelling/issues/74
   display_hyperlinks <-
     requireNamespace("cli", quietly = TRUE) &&
     cli::ansi_has_hyperlink_support()
 
   if (display_hyperlinks) {
-    for(i in seq_len(nrow(x))){
-      # print word
-      cat(pretty_names[i])
-      for (j in seq_along(x$file_names[[i]])) {
-        # each file name
-        # print separator only for subsequent files
-        if (j != 1)  cat(paste0("\n", sprintf(fmt, "")))
-        found_str <- x$found[[i]][[j]]
-        first_match <- regmatches(found_str, m = regexpr(".+\\:\\d+", found_str))
-        lnk <- cli::style_hyperlink(
-          text = first_match,
-          url = x$file_names[[i]][[j]],
-          params = list(line = x$line_numbers[[i]][[j]][1L], col = 1)
-        )
-        cat(lnk) #file_name:<line>
-        n_matches <- length(x$line_numbers[[i]][[j]])
-        if (n_matches > 1) {
-          for (k in 2:n_matches) {
-            if (k == 2) cat(",")
-            # link for each line of each file.
-            lnk_line <- cli::style_hyperlink(
-              text = x$line_numbers[[i]][[j]][k],
-              url = x$file_names[[i]][[j]],
-              params = list(line = x$line_numbers[[i]][[j]][k], col = 1)
-            )
-            cat(lnk_line) # <line>
-            if (k != n_matches) cat(",")
-          }
-        }
-      }
-      cat("\n")
-    }
-  } else {
-    for(i in seq_len(nrow(x))){
-      cat(pretty_names[i])
-      cat(paste(x$found[[i]], collapse = paste0("\n", sprintf(fmt, ""))))
-      cat("\n")
-    }
+    # Diplay cli hyperlinks if console supports it.
+    # Show in RStudio interactively .
+    # https://github.com/ropensci/spelling/issues/74
+    display_hyperlinks(x, pretty_names, words, fmt)
+    return(invisible(x))
+  }
+  for(i in seq_len(nrow(x))){
+    cat(pretty_names[i])
+    cat(paste(x$found[[i]], collapse = paste0("\n", sprintf(fmt, ""))))
+    cat("\n")
   }
   invisible(x)
+}
+
+display_hyperlinks <- function(x, pretty_names, words, fmt) {
+  for(i in seq_len(nrow(x))){
+    # print word
+    cat(pretty_names[i])
+    for (j in seq_along(x$file_names[[i]])) {
+      # each file name
+      # print separator only for subsequent files
+      if (j != 1)  cat(paste0("\n", sprintf(fmt, "")))
+      found_str <- x$found[[i]][[j]]
+      first_match <- regmatches(found_str, m = regexpr(".+\\:\\d+", found_str))
+      lnk <- cli::style_hyperlink(
+        text = first_match,
+        url = x$file_names[[i]][[j]],
+        params = list(line = x$line_numbers[[i]][[j]][1L], col = 1)
+      )
+      cat(lnk) #file_name:<line>
+      n_matches <- length(x$line_numbers[[i]][[j]])
+      if (n_matches > 1) {
+        for (k in 2:n_matches) {
+          if (k == 2) cat(",")
+          # link for each line of each file.
+          lnk_line <- cli::style_hyperlink(
+            text = x$line_numbers[[i]][[j]][k],
+            url = x$file_names[[i]][[j]],
+            params = list(line = x$line_numbers[[i]][[j]][k], col = 1)
+          )
+          cat(lnk_line) # <line>
+          if (k != n_matches) cat(",")
+        }
+      }
+    }
+    cat("\n")
+  }
+
 }
 
 #' @export


### PR DESCRIPTION
Fixes #74 

Supersedes #75

Using a different approach, with most of the code change occurring in the print method.

However, to make it a bit more efficient and less clunky, I need the full file names.. The function looks ugly, but I tried using the existing output as much as possible. I built my method based on the following nested data frame / structure.

```r
  tibble::tibble(
     file = c("file1", "file2"),
     word = list(file1 = c("aa", "bb"), file2 = c("cc")),
     line = list(file1 = list(aa = c(1, 3), bb = c(1)), file2 = list(cc = c(1, 2)))
 )
```



Let me know if you prefer this approach!

Example output
![Capture d’écran, le 2024-03-10 à 5 48 05 p m](https://github.com/ropensci/spelling/assets/52606734/cc60be85-8aa4-4d54-9d3a-0ef21cc9df4a)

